### PR TITLE
feat: add Spanish UI locale

### DIFF
--- a/i18n/__init__.py
+++ b/i18n/__init__.py
@@ -1,0 +1,70 @@
+"""GUI strings for Pad Zero.
+
+English is the default. Spanish is used when Windows (or LANG) is a Spanish
+locale. Set PADZERO_LANG=en or es to force one language.
+
+Technical-detail keys (model, serial, key group, …) stay in English; they
+are not in this catalog.
+"""
+from __future__ import annotations
+
+import locale
+import os
+
+from i18n import en as _en
+from i18n import es as _es
+
+_SUPPORTED = {"en", "es"}
+_CATALOGS = {"en": _en.STRINGS, "es": _es.STRINGS}
+
+
+def language_from_tag(tag: str | None) -> str:
+    if not tag:
+        return "en"
+    normalized = tag.replace("-", "_").split(".")[0].strip().lower()
+    if normalized == "es" or normalized.startswith(("es_", "spanish")):
+        return "es"
+    return "en"
+
+
+def current_language() -> str:
+    override = os.environ.get("PADZERO_LANG", "").strip().lower()
+    if override in _SUPPORTED:
+        return override
+
+    try:
+        locale_name = locale.getlocale()[0]
+    except ValueError:
+        locale_name = None
+
+    if locale_name:
+        return language_from_tag(locale_name)
+
+    for key in ("LC_ALL", "LC_MESSAGES", "LANG"):
+        if language_from_tag(os.environ.get(key)) == "es":
+            return "es"
+    return "en"
+
+
+def load(language: str | None = None) -> dict[str, str]:
+    code = language if language in _SUPPORTED else current_language()
+    return _CATALOGS[code]
+
+
+STRINGS = load()
+
+
+def t(key: str, **kwargs) -> str:
+    """Look up a GUI string; fall back to English if a key is missing."""
+    text = STRINGS.get(key) or _en.STRINGS.get(key) or key
+    if kwargs:
+        return text.format(**kwargs)
+    return text
+
+
+missing = set(_en.STRINGS) - set(_es.STRINGS)
+extra = set(_es.STRINGS) - set(_en.STRINGS)
+if missing or extra:
+    raise RuntimeError(
+        "i18n catalogs are out of sync: missing=%s extra=%s" % (sorted(missing), sorted(extra))
+    )

--- a/i18n/en.py
+++ b/i18n/en.py
@@ -1,0 +1,191 @@
+# Default (English) GUI copy. Keep this wording in lockstep with the window.
+
+STRINGS = {
+    "app_title": "Pad Zero",
+    "what_is_this": "What is this?",
+    "looking_for_printer": "Looking for your printer...",
+    "technical_details_closed": "▸  Technical details",
+    "technical_details_open": "▾  Technical details",
+    "reset_the_counter": "Reset the counter",
+    "check_level_now": "Check level now",
+    "save_a_backup": "Save a backup",
+    "lost_connection_status": "Lost the connection to the printer",
+    "lost_connection_body": (
+        "PadZero couldn't get a clean connection to the printer.\n\n"
+        "This is almost always a stuck USB connection, not a problem with your printer.\n\n"
+        "Try this:\n"
+        "1. Unplug the USB cable, wait a few seconds, then plug it back in.\n"
+        "2. Click Reset again.\n\n"
+        "If it still fails, restart your PC and try once more - that clears the USB "
+        "connection completely."
+    ),
+    "something_went_wrong": "Something went wrong: {error}",
+    "no_counter_data": "no counter data",
+    "no_readable_counters": "no readable counters",
+    "counter_read_ok": "counter read OK",
+    "nothing_to_clear_short": "nothing to clear",
+    "stored_value_one": "{n} stored value",
+    "stored_value_other": "{n} stored values",
+    "readings_this_session": "READINGS THIS SESSION",
+    "printer_connected_checking": "Printer connected, checking...",
+    "printer_unplugged": "Printer unplugged",
+    "checking_usb": "Checking the USB connection...",
+    "no_printer_found": "No printer found",
+    "no_printer_verdict": (
+        "Nothing is answering on USB. It is almost always one of the things below, "
+        "and they are quick to check."
+    ),
+    "step_socket_title": "Check which socket the cable is in",
+    "step_socket_body": (
+        "The USB cable must go in the wide, flat USB socket. The two small square "
+        "sockets marked LINE and EXT are telephone jacks for the fax and do nothing "
+        "for this."
+    ),
+    "step_driver_title": "Install Epson's own driver",
+    "step_driver_body": (
+        "Windows installs a basic driver that can print but cannot talk to the printer "
+        "properly. Download the driver for your model from epson.com, install it, then "
+        "click Check again."
+    ),
+    "step_power_title": "Make sure the printer is switched on",
+    "step_power_body": (
+        "It needs to be powered up and finished starting, not asleep mid-boot."
+    ),
+    "not_connected": "Not connected",
+    "untested_verdict": (
+        "This printer works, but Pad Zero has never been tested on this model, so it "
+        "will not change anything on it."
+    ),
+    "help_add_model_title": "Help get your model added",
+    "help_add_model_body": (
+        "Click Save a backup, then send the file that appears. It contains the "
+        "settings needed to support your printer."
+    ),
+    "open_issue_tracker": "Open the issue tracker",
+    "model_not_recognised": "Model not recognised. Reading only.",
+    "connected_no_percent": (
+        "Connected and working. This model does not report a percentage, but the "
+        "counter can still be reset."
+    ),
+    "ready": "Ready",
+    "counter_full_verdict": (
+        "The waste ink counter is full. This is why your printer has stopped printing."
+    ),
+    "counter_full_status": "Counter full",
+    "nearly_full_verdict": "Nearly full. Your printer will stop printing soon.",
+    "nearly_full_status": "Nearly full",
+    "everything_fine": "Everything looks fine. There is nothing you need to do.",
+    "healthy": "Healthy",
+    "about_percentages": "About these percentages",
+    "about_percentages_body": (
+        "This exact model is not in the percentage database yet, so the figures above "
+        "are worked out from {n} closely matching Epson models that store their "
+        "counters at the same places. Treat them as a good estimate rather than an "
+        "exact reading. The reset itself is not affected."
+    ),
+    "how_full": "HOW FULL THE COUNTER IS",
+    "before_and_after": "BEFORE AND AFTER",
+    "approximate_suffix": "   (APPROXIMATE)",
+    "waste_counter_heading": "WASTE COUNTER",
+    "nothing_to_clear": "Nothing to clear",
+    "nothing_to_clear_body": (
+        "This printer's waste counter is already at its lowest setting. There is "
+        "nothing for Pad Zero to reset, and nothing you need to do."
+    ),
+    "some_usage": "Some usage recorded",
+    "some_usage_body_one": (
+        "Resetting would clear {n} stored value. This printer does not report a "
+        "percentage, so Pad Zero cannot show you a bar, but the reset works the "
+        "same way."
+    ),
+    "some_usage_body_other": (
+        "Resetting would clear {n} stored values. This printer does not report a "
+        "percentage, so Pad Zero cannot show you a bar, but the reset works the "
+        "same way."
+    ),
+    "counter_read_successfully": "Counter read successfully",
+    "counter_read_successfully_body": (
+        "This printer does not report its level as a percentage. Pad Zero can still "
+        "read and reset it."
+    ),
+    "exact_numbers_hint": "The exact numbers are under Technical details below.",
+    "resetting_will_not_empty": "Resetting will not empty the pads",
+    "pad_advice_body": (
+        "The counter is only an estimate of how much ink has soaked into the pads "
+        "inside your printer. Resetting it gets you printing again, but the ink is "
+        "still in there. If the pads are full it can eventually leak out of the "
+        "bottom.\n\n"
+        "Put a towel or tray under the printer, and order a replacement pad or a "
+        "waste tank kit."
+    ),
+    "where_to_buy_pad": "Where to buy a pad",
+    "nothing_connected": "Nothing connected.",
+    "reading_memory": "Reading the printer's memory, this takes a moment...",
+    "backup_saved_status": "Backup saved",
+    "backup_saved_title": "Backup saved",
+    "backup_saved_body": (
+        "A copy of your printer's settings was saved to:\n\n{path}\n\n"
+        "Keep this. If anything ever goes wrong it can be used to put things back."
+    ),
+    "no_reset_known": "No reset is known for this model, so nothing will be changed.",
+    "reset_confirm_title": "Reset the waste ink counter?",
+    "reset_confirm_body": (
+        "This tells your {model} that its waste ink pads are empty, so it will start "
+        "printing again.\n\n"
+        "IT DOES NOT EMPTY THE PADS.\n\n"
+        "The ink is still inside the printer. If the pads are full, ink can leak out "
+        "of the bottom onto whatever it is sitting on. Put a towel underneath and "
+        "fit a new pad when you can.\n\n"
+        "A backup is saved automatically before anything is changed.\n\n"
+        "Go ahead?"
+    ),
+    "cancelled": "Cancelled",
+    "saving_backup_then_resetting": "Saving a backup, then resetting...",
+    "after_reset_note": "<- after reset",
+    "done_power_cycle": "Done. Turn the printer off and on again.",
+    "reset_complete_title": "Reset complete",
+    "reset_complete_body": (
+        "The counter has been reset.\n\n"
+        "NEXT: turn the printer off, wait ten seconds, and turn it back on. It "
+        "should print again.\n\n"
+        "Then order a replacement pad. The ink is still inside the printer and this "
+        "will happen again.\n\n"
+        "Backup saved to:\n{path}"
+    ),
+    "some_changes_refused": "Some changes were refused",
+    "reset_did_not_finish_title": "Reset did not finish",
+    "reset_did_not_finish_body": (
+        "The printer refused some of the changes.\n\n"
+        "Your backup is safe at:\n{path}\n\n"
+        "This usually means the printer's firmware blocks resets. Nothing has been "
+        "damaged."
+    ),
+    "what_pad_zero_does": "What Pad Zero does",
+    "explain_body": (
+        "What this tool does, and what it does not\n\n"
+        "  Your printer keeps a counter estimating how much waste ink has gone into\n"
+        "  the absorbent pads inside it. There is no sensor. It is an estimate that\n"
+        "  goes up every time the printer cleans its head, charges ink, powers on,\n"
+        "  or prints borderless.\n\n"
+        "  When that estimate crosses a threshold the printer refuses to print and\n"
+        "  tells you to contact Epson.\n\n"
+        "  This tool sets the counter back to zero. That is all it does.\n\n"
+        "  It does NOT empty the pads. The ink is still in there. If the pads were\n"
+        "  genuinely saturated, resetting the counter means the printer will keep\n"
+        "  pumping ink into full foam, and eventually that ink comes out of the\n"
+        "  bottom of the printer onto whatever it is sitting on.\n\n"
+        "  The real fix is replacing the pad or fitting an external waste tank.\n"
+        "  Reset the counter to get printing again, then fix it properly.\n\n"
+        "  Put something absorbent under the printer in the meantime."
+    ),
+    "close": "Close",
+    "could_not_open_window": (
+        "Pad Zero could not open its window.\n\n{error}\n\n"
+        "This is usually a missing Tcl/Tk installation."
+    ),
+    "could_not_start": "Could not start: {error}",
+    "stopped_unexpectedly_title": "Pad Zero stopped unexpectedly",
+    "stopped_unexpectedly_body": (
+        "Something went wrong.\n\nPlease copy this and open an issue at:\n{url}\n\n{detail}"
+    ),
+}

--- a/i18n/es.py
+++ b/i18n/es.py
@@ -1,0 +1,198 @@
+# Latin American Spanish. Same plain tone as the English: no hype, especially
+# on the pad warning. Brand name, LINE/EXT, epson.com and model names stay as-is.
+
+STRINGS = {
+    "app_title": "Pad Zero",
+    "what_is_this": "¿Qué es esto?",
+    "looking_for_printer": "Buscando tu impresora...",
+    "technical_details_closed": "▸  Detalles técnicos",
+    "technical_details_open": "▾  Detalles técnicos",
+    "reset_the_counter": "Resetear el contador",
+    "check_level_now": "Comprobar nivel",
+    "save_a_backup": "Guardar una copia",
+    "lost_connection_status": "Se perdió la conexión con la impresora",
+    "lost_connection_body": (
+        "Pad Zero no pudo conectar bien con la impresora.\n\n"
+        "Casi siempre es una conexión USB atascada, no un fallo físico.\n\n"
+        "Prueba esto:\n"
+        "1. Desconecta el cable USB, espera unos segundos y vuelve a conectarlo.\n"
+        "2. Pulsa Resetear otra vez.\n\n"
+        "Si sigue fallando, reinicia el PC e inténtalo de nuevo: eso limpia la "
+        "conexión USB por completo."
+    ),
+    "something_went_wrong": "Algo salió mal: {error}",
+    "no_counter_data": "sin datos de contador",
+    "no_readable_counters": "sin contadores legibles",
+    "counter_read_ok": "lectura del contador OK",
+    "nothing_to_clear_short": "nada que borrar",
+    "stored_value_one": "{n} valor guardado",
+    "stored_value_other": "{n} valores guardados",
+    "readings_this_session": "LECTURAS DE ESTA SESIÓN",
+    "printer_connected_checking": "Impresora conectada, comprobando...",
+    "printer_unplugged": "Impresora desconectada",
+    "checking_usb": "Comprobando la conexión USB...",
+    "no_printer_found": "No se encontró ninguna impresora",
+    "no_printer_verdict": (
+        "No hay respuesta en el USB. Casi siempre es una de las siguientes cosas, "
+        "y son fáciles de revisar."
+    ),
+    "step_socket_title": "Revisa en qué puerto está el cable",
+    "step_socket_body": (
+        "El cable USB tiene que ir en el puerto USB plano y ancho. Los dos "
+        "conectores cuadrados pequeños marcados LINE y EXT son tomas telefónicas "
+        "del fax y no sirven para esto."
+    ),
+    "step_driver_title": "Instala el driver de Epson",
+    "step_driver_body": (
+        "Windows instala un driver básico que puede imprimir pero no habla "
+        "bien con la impresora. Descarga el de tu modelo en epson.com, instálalo "
+        "y pulsa Comprobar otra vez."
+    ),
+    "step_power_title": "Asegúrate de que la impresora esté encendida",
+    "step_power_body": (
+        "Debe estar encendida y haber terminado de arrancar, no a mitad "
+        "del inicio."
+    ),
+    "not_connected": "Sin conexión",
+    "untested_verdict": (
+        "Esta impresora funciona, pero Pad Zero nunca se ha probado en este "
+        "modelo, por lo que no modificará nada en ella."
+    ),
+    "help_add_model_title": "Ayuda a añadir tu modelo",
+    "help_add_model_body": (
+        "Pulsa Guardar una copia y envía el archivo que aparece. Trae los "
+        "ajustes necesarios para soportar tu impresora."
+    ),
+    "open_issue_tracker": "Abrir el seguimiento de incidencias",
+    "model_not_recognised": "Modelo no reconocido. Solo lectura.",
+    "connected_no_percent": (
+        "Conectada y funcionando. Este modelo no reporta un porcentaje, pero "
+        "el contador igual se puede resetear."
+    ),
+    "ready": "Lista",
+    "counter_full_verdict": (
+        "El contador de tinta residual está lleno. Por eso la impresora dejó "
+        "de imprimir."
+    ),
+    "counter_full_status": "Contador lleno",
+    "nearly_full_verdict": "Casi lleno. La impresora dejará de imprimir pronto.",
+    "nearly_full_status": "Casi lleno",
+    "everything_fine": "Todo bien. No tienes que hacer nada.",
+    "healthy": "En buen estado",
+    "about_percentages": "Sobre estos porcentajes",
+    "about_percentages_body": (
+        "Este modelo exacto aún no está en la base de porcentajes, así que las "
+        "cifras de arriba se calculan a partir de {n} modelos Epson parecidos "
+        "que guardan los contadores en los mismos sitios. Tómalas como una buena "
+        "estimación, no como una lectura exacta. El reseteo en sí no cambia."
+    ),
+    "how_full": "CUÁN LLENO ESTÁ EL CONTADOR",
+    "before_and_after": "ANTES Y DESPUÉS",
+    "approximate_suffix": "   (APROXIMADO)",
+    "waste_counter_heading": "CONTADOR DE RESIDUAL",
+    "nothing_to_clear": "Nada que borrar",
+    "nothing_to_clear_body": (
+        "El contador de residual de esta impresora ya está en su valor más bajo. "
+        "Pad Zero no tiene nada que resetear, y tú no tienes que hacer nada."
+    ),
+    "some_usage": "Hay uso registrado",
+    "some_usage_body_one": (
+        "Resetear borraría {n} valor guardado. Esta impresora no reporta un "
+        "porcentaje, así que Pad Zero no puede mostrarte una barra, pero el "
+        "reseteo funciona igual."
+    ),
+    "some_usage_body_other": (
+        "Resetear borraría {n} valores guardados. Esta impresora no reporta un "
+        "porcentaje, así que Pad Zero no puede mostrarte una barra, pero el "
+        "reseteo funciona igual."
+    ),
+    "counter_read_successfully": "Contador leído bien",
+    "counter_read_successfully_body": (
+        "Esta impresora no reporta su nivel como porcentaje. Pad Zero aún "
+        "puede leerlo y resetearlo."
+    ),
+    "exact_numbers_hint": "Los números exactos están en Detalles técnicos, abajo.",
+    "resetting_will_not_empty": "Resetear no vacía las almohadillas",
+    "pad_advice_body": (
+        "El contador solo es una estimación de cuánta tinta ha empapado las "
+        "almohadillas dentro de la impresora. Resetearlo te deja imprimir otra "
+        "vez, pero la tinta sigue ahí. Si las almohadillas están llenas, con el "
+        "tiempo puede salirse por abajo.\n\n"
+        "Pon una toalla o una bandeja debajo de la impresora, y pide una "
+        "almohadilla de reemplazo o un kit de tinta residual."
+    ),
+    "where_to_buy_pad": "Dónde comprar una almohadilla",
+    "nothing_connected": "Nada conectado.",
+    "reading_memory": "Leyendo memoria de la impresora; tardará un momento...",
+    "backup_saved_status": "Copia guardada",
+    "backup_saved_title": "Copia guardada",
+    "backup_saved_body": (
+        "Se guardó una copia de los ajustes de tu impresora en:\n\n{path}\n\n"
+        "Consérvala. Si algo sale mal, sirve para dejar las cosas como estaban."
+    ),
+    "no_reset_known": (
+        "No hay un reseteo conocido para este modelo, así que no se va a "
+        "cambiar nada."
+    ),
+    "reset_confirm_title": "¿Resetear el contador de tinta residual?",
+    "reset_confirm_body": (
+        "Esto le dice a tu {model} que las almohadillas de tinta residual están "
+        "vacías, para que vuelva a imprimir.\n\n"
+        "ESTO NO VACÍA LAS ALMOHADILLAS.\n\n"
+        "La tinta sigue dentro de la impresora. Si las almohadillas están llenas, "
+        "la tinta puede salirse por abajo sobre lo que tenga debajo. Pon una "
+        "toalla y cambia la almohadilla cuando puedas.\n\n"
+        "Antes de cambiar nada se guarda una copia sola.\n\n"
+        "¿Seguimos?"
+    ),
+    "cancelled": "Cancelado",
+    "saving_backup_then_resetting": "Guardando una copia y luego reseteando...",
+    "after_reset_note": "<- tras reseteo",
+    "done_power_cycle": "Listo. Apaga la impresora y vuélvela a encender.",
+    "reset_complete_title": "Reseteo listo",
+    "reset_complete_body": (
+        "El contador se reseteó.\n\n"
+        "SIGUIENTE: apaga la impresora, espera diez segundos y enciéndela otra vez. "
+        "Debería imprimir nuevamente.\n\n"
+        "Luego ordena una almohadilla de repuesto. La tinta sigue dentro de la "
+        "impresora y esto volverá a pasar.\n\n"
+        "Copia guardada en:\n{path}"
+    ),
+    "some_changes_refused": "Algunos cambios se rechazaron",
+    "reset_did_not_finish_title": "El reseteo no terminó",
+    "reset_did_not_finish_body": (
+        "La impresora rechazó algunos de los cambios.\n\n"
+        "Tu copia está a salvo en:\n{path}\n\n"
+        "Casi siempre significa que el firmware de la impresora bloquea los "
+        "reseteos. No se dañó nada."
+    ),
+    "what_pad_zero_does": "Qué hace Pad Zero",
+    "explain_body": (
+        "Qué hace esta herramienta, y qué no hace\n\n"
+        "  Tu impresora lleva un contador que estima cuánta tinta residual ha\n"
+        "  ido a las almohadillas internas. No hay un sensor. Es una estimación\n"
+        "  que sube cada vez que la impresora limpia su cabezal, carga tinta,\n"
+        "  se enciende o imprime sin bordes.\n\n"
+        "  Cuando esa estimación cruza un umbral, la impresora se niega a imprimir\n"
+        "  y te dice que contactes a Epson.\n\n"
+        "  Esta herramienta pone el contador en cero. Eso es todo lo que hace.\n\n"
+        "  NO vacía las almohadillas. La tinta sigue ahí. Si las almohadillas\n"
+        "  estaban realmente saturadas, resetear el contador significa que la\n"
+        "  impresora sigue metiendo tinta en una esponja llena, y eventualmente esa\n"
+        "  tinta saldrá por debajo hacia la superficie en la que repose.\n\n"
+        "  La solución real es cambiar la almohadilla o poner un tanque\n"
+        "  residual externo. Resetea el contador para volver a imprimir, y\n"
+        "  después haz el arreglo correcto.\n\n"
+        "  Mientras tanto, pon algo absorbente bajo la impresora."
+    ),
+    "close": "Cerrar",
+    "could_not_open_window": (
+        "Pad Zero no pudo abrir su ventana.\n\n{error}\n\n"
+        "Suele ser una instalación de Tcl/Tk faltante."
+    ),
+    "could_not_start": "No se pudo iniciar: {error}",
+    "stopped_unexpectedly_title": "Pad Zero se detuvo inesperadamente",
+    "stopped_unexpectedly_body": (
+        "Algo salió mal.\n\nCopia esto y abre una incidencia en:\n{url}\n\n{detail}"
+    ),
+}

--- a/padzero_gui.py
+++ b/padzero_gui.py
@@ -106,6 +106,7 @@ if not getattr(sys, "frozen", False):
     sys.path.insert(0, os.path.join(HERE, "reinkpy"))
 
 import padzero as core            # noqa: E402
+from i18n import t                # noqa: E402
 
 PADS_URL = "https://www.amazon.com/s?k=epson+waste+ink+pad+kit"
 ISSUES_URL = "https://github.com/Damnitbran/padzero/issues"
@@ -155,7 +156,7 @@ class App:
         # change over time rather than a number you have to have memorised.
         self.history = []
 
-        root.title("Pad Zero")
+        root.title(t("app_title"))
         root.configure(bg=BG)
         root.geometry("%dx%d" % (S(720), S(720)))
         root.minsize(S(660), S(640))
@@ -176,8 +177,8 @@ class App:
     def _build(self):
         bar = tk.Frame(self.root, bg=BG)
         bar.pack(fill="x", padx=S(24), pady=(S(18), 0))
-        tk.Label(bar, text="Pad Zero", font=F_APP, bg=BG, fg=FG).pack(side="left")
-        self.b_help = flat_button(bar, "What is this?", self.show_explain,
+        tk.Label(bar, text=t("app_title"), font=F_APP, bg=BG, fg=FG).pack(side="left")
+        self.b_help = flat_button(bar, t("what_is_this"), self.show_explain,
                                   bg=BG, fg=DIM, padx=S(10), pady=S(6))
         self.b_help.pack(side="right")
 
@@ -188,7 +189,7 @@ class App:
         self.l_dot = tk.Label(self.card, text="", font=("Segoe UI", 30),
                               bg=CARD, fg=DIM)
         self.l_dot.pack(anchor="w", padx=S(26), pady=(S(20), 0))
-        self.l_model = tk.Label(self.card, text="Looking for your printer...",
+        self.l_model = tk.Label(self.card, text=t("looking_for_printer"),
                                 font=F_BIG, bg=CARD, fg=FG, anchor="w",
                                 justify="left", wraplength=S(600))
         self.l_model.pack(fill="x", padx=S(26))
@@ -206,7 +207,7 @@ class App:
         self.l_status.pack(side="bottom", fill="x", padx=S(24), pady=(S(6), S(12)))
 
         self.details = tk.Frame(self.root, bg=CARD2)
-        self.b_details = flat_button(self.root, "▸  Technical details",
+        self.b_details = flat_button(self.root, t("technical_details_closed"),
                                      self.toggle_details, bg=BG, fg=FAINT,
                                      font=F_SMALL, padx=0, pady=6)
         self.b_details.pack(side="bottom", anchor="w", padx=S(24))
@@ -218,15 +219,15 @@ class App:
         # used to sit in the top-right corner and people looked for it here.
         act = tk.Frame(self.root, bg=BG)
         act.pack(side="bottom", fill="x", padx=S(24), pady=(S(12), S(10)))
-        self.b_reset = flat_button(act, "Reset the counter", self.do_reset,
+        self.b_reset = flat_button(act, t("reset_the_counter"), self.do_reset,
                                    bg=ACCENT, fg="#0B1417", font=F_BTN,
                                    padx=S(26), pady=S(14))
         self.b_reset.pack(side="left")
-        self.b_refresh = flat_button(act, "Check level now", self.scan,
+        self.b_refresh = flat_button(act, t("check_level_now"), self.scan,
                                      bg=CARD2, fg=FG, font=F_BTN,
                                      padx=S(20), pady=S(14))
         self.b_refresh.pack(side="left", padx=(S(10), 0))
-        self.b_backup = flat_button(act, "Save a backup", self.do_backup,
+        self.b_backup = flat_button(act, t("save_a_backup"), self.do_backup,
                                     padx=S(16), pady=S(14))
         self.b_backup.pack(side="left", padx=(S(10), 0))
 
@@ -275,22 +276,13 @@ class App:
                 self.busy = False
                 self._buttons(True)
                 if err and self._is_comms_glitch(err):
-                    self.status("Lost the connection to the printer", BAD)
+                    self.status(t("lost_connection_status"), BAD)
                     messagebox.showwarning(
-                        "Pad Zero",
-                        "PadZero couldn't get a clean connection to the "
-                        "printer.\n\n"
-                        "This is almost always a stuck USB connection, not a "
-                        "problem with your printer.\n\n"
-                        "Try this:\n"
-                        "1. Unplug the USB cable, wait a few seconds, then "
-                        "plug it back in.\n"
-                        "2. Click Reset again.\n\n"
-                        "If it still fails, restart your PC and try once more "
-                        "- that clears the USB connection completely.")
+                        t("app_title"),
+                        t("lost_connection_body"))
                 elif err:
-                    self.status("Something went wrong: %s" % err, BAD)
-                    messagebox.showerror("Pad Zero", str(err))
+                    self.status(t("something_went_wrong", error=err), BAD)
+                    messagebox.showerror(t("app_title"), str(err))
                 else:
                     getattr(self, "after_" + tag)(res)
         except queue.Empty:
@@ -307,7 +299,7 @@ class App:
         a healthy printer look alarming.
         """
         if not counters:
-            return "no counter data"
+            return t("no_counter_data")
 
         pcts = [c for c in counters if c.get("percent") is not None]
         if pcts:
@@ -316,18 +308,20 @@ class App:
                               for c in pcts)
 
         if not any("values" in c for c in counters):
-            return "no readable counters"
+            return t("no_readable_counters")
 
         try:
             plan, _src = self.printer.reset_plan()
             current = self.printer.read([a for a, _ in plan])
             pending = sum(1 for a, v in plan if current.get(a) != v)
         except Exception:
-            return "counter read OK"
+            return t("counter_read_ok")
 
         if pending == 0:
-            return "nothing to clear"
-        return "%d stored value%s" % (pending, "" if pending == 1 else "s")
+            return t("nothing_to_clear_short")
+        if pending == 1:
+            return t("stored_value_one", n=pending)
+        return t("stored_value_other", n=pending)
 
     def _log_reading(self, counters, note=""):
         stamp = datetime.now().strftime("%H:%M:%S")
@@ -339,7 +333,7 @@ class App:
         if len(self.history) < 2:
             return  # a single reading is not a history
 
-        tk.Label(self.hist_frame, text="READINGS THIS SESSION",
+        tk.Label(self.hist_frame, text=t("readings_this_session"),
                  font=("Segoe UI", 9, "bold"), bg=BG, fg=FAINT,
                  anchor="w").pack(fill="x", pady=(6, 4))
 
@@ -375,9 +369,9 @@ class App:
                 elif paths != self._known_paths:
                     self._known_paths = paths
                     if paths:
-                        self.status("Printer connected, checking...", ACCENT)
+                        self.status(t("printer_connected_checking"), ACCENT)
                     else:
-                        self.status("Printer unplugged", WARN)
+                        self.status(t("printer_unplugged"), WARN)
                     self.scan()
         except Exception:
             pass  # never let the watchdog kill the window
@@ -410,9 +404,9 @@ class App:
 
     # --------------------------------------------------------------- scan
     def scan(self):
-        self.status("Checking the USB connection...")
+        self.status(t("checking_usb"))
         self.l_dot.configure(text="●", fg=DIM)
-        self.l_model.configure(text="Looking for your printer...")
+        self.l_model.configure(text=t("looking_for_printer"))
         self.l_verdict.configure(text="", fg=DIM)
         self._clear(self.levels)
         self._clear(self.advice)
@@ -452,28 +446,22 @@ class App:
     # ------------------------------------------------------------- states
     def _state_no_printer(self):
         self.l_dot.configure(text="●", fg=BAD)
-        self.l_model.configure(text="No printer found")
+        self.l_model.configure(text=t("no_printer_found"))
         self.l_verdict.configure(
-            text="Nothing is answering on USB. It is almost always one of "
-                 "the things below, and they are quick to check.", fg=DIM)
+            text=t("no_printer_verdict"), fg=DIM)
         self._reset_enabled(False)
         self.b_backup.configure(state="disabled")
         self._details("")
 
         self._steps(self.advice, [
-            ("Check which socket the cable is in",
-             "The USB cable must go in the wide, flat USB socket. The two "
-             "small square sockets marked LINE and EXT are telephone jacks "
-             "for the fax and do nothing for this."),
-            ("Install Epson's own driver",
-             "Windows installs a basic driver that can print but cannot talk "
-             "to the printer properly. Download the driver for your model "
-             "from epson.com, install it, then click Check again."),
-            ("Make sure the printer is switched on",
-             "It needs to be powered up and finished starting, not asleep "
-             "mid-boot."),
+            (t("step_socket_title"),
+             t("step_socket_body")),
+            (t("step_driver_title"),
+             t("step_driver_body")),
+            (t("step_power_title"),
+             t("step_power_body")),
         ])
-        self.status("Not connected", BAD)
+        self.status(t("not_connected"), BAD)
 
     def _state_found(self, pr, counters, worst):
         self.l_model.configure(text=pr.model)
@@ -482,51 +470,47 @@ class App:
         if pr.coverage == "none":
             self.l_dot.configure(text="●", fg=WARN)
             self.l_verdict.configure(
-                text="This printer works, but Pad Zero has never been tested "
-                     "on this model, so it will not change anything on it.",
+                text=t("untested_verdict"),
                 fg=WARN)
             self._reset_enabled(False)
             self._steps(self.advice, [
-                ("Help get your model added",
-                 "Click Save a backup, then send the file that appears. It "
-                 "contains the settings needed to support your printer."),
-            ], button=("Open the issue tracker",
+                (t("help_add_model_title"),
+                 t("help_add_model_body")),
+            ], button=(t("open_issue_tracker"),
                        lambda: webbrowser.open(ISSUES_URL)))
-            self.status("Model not recognised. Reading only.", WARN)
+            self.status(t("model_not_recognised"), WARN)
 
         elif worst is None:
             self.l_dot.configure(text="●", fg=GOOD)
             self.l_verdict.configure(
-                text="Connected and working. This model does not report a "
-                     "percentage, but the counter can still be reset.", fg=DIM)
+                text=t("connected_no_percent"), fg=DIM)
             self._reset_enabled(True)
-            self.status("Ready", GOOD)
+            self.status(t("ready"), GOOD)
 
         elif worst >= 100:
             self.l_dot.configure(text="●", fg=BAD)
             self.l_verdict.configure(
-                text="The waste ink counter is full. This is why your printer "
-                     "has stopped printing.", fg=BAD)
+                text=t("counter_full_verdict"), fg=BAD)
             self._reset_enabled(True)
             self._pad_advice(urgent=True)
-            self.status("Counter full", BAD)
+            self.status(t("counter_full_status"), BAD)
 
         elif worst >= 85:
             self.l_dot.configure(text="●", fg=WARN)
             self.l_verdict.configure(
-                text="Nearly full. Your printer will stop printing soon.",
+                text=t("nearly_full_verdict"),
                 fg=WARN)
             self._reset_enabled(True)
             self._pad_advice(urgent=False)
-            self.status("Nearly full", WARN)
+            self.status(t("nearly_full_status"), WARN)
 
         else:
             self.l_dot.configure(text="●", fg=GOOD)
             self.l_verdict.configure(
-                text="Everything looks fine. There is nothing you need to do.",
+                text=t("everything_fine"),
                 fg=GOOD)
             self._reset_enabled(True)
-            self.status("Healthy", GOOD)
+            self.status(t("healthy"), GOOD)
 
         self._bars(counters)
 
@@ -534,18 +518,12 @@ class App:
                 c.get("percent") is not None for c in (counters or [])):
             note = tk.Frame(self.advice, bg=CARD)
             note.pack(fill="x")
-            tk.Label(note, text="About these percentages",
+            tk.Label(note, text=t("about_percentages"),
                      font=("Segoe UI", 10, "bold"), bg=CARD, fg=DIM,
                      anchor="w").pack(fill="x", padx=S(18), pady=(S(12), S(2)))
             basis = (pr.inferred or {}).get("basis") or []
             tk.Label(note,
-                     text=("This exact model is not in the percentage database "
-                           "yet, so the figures above are worked out from %d "
-                           "closely matching Epson models that store their "
-                           "counters at the same places. Treat them as a good "
-                           "estimate rather than an exact reading. The reset "
-                           "itself is not affected."
-                           % len(basis)),
+                     text=t("about_percentages_body", n=len(basis)),
                      font=F_SMALL, bg=CARD, fg=FAINT, anchor="w",
                      justify="left", wraplength=S(600)).pack(
                 fill="x", padx=S(18), pady=(0, S(14)))
@@ -594,9 +572,9 @@ class App:
                     if c.get("percent") is not None}
 
         if readable:
-            heading = "BEFORE AND AFTER" if prev else "HOW FULL THE COUNTER IS"
+            heading = t("before_and_after") if prev else t("how_full")
             if any(c.get("approx") for c in readable) and not prev:
-                heading += "   (APPROXIMATE)"
+                heading += t("approximate_suffix")
             tk.Label(self.levels, text=heading,
                      font=("Segoe UI", 9, "bold"), bg=BG,
                      fg=ACCENT if prev else FAINT,
@@ -659,25 +637,22 @@ class App:
         box = tk.Frame(self.levels, bg=CARD)
         box.pack(fill="x")
 
-        tk.Label(box, text="WASTE COUNTER", font=("Segoe UI", 9, "bold"),
+        tk.Label(box, text=t("waste_counter_heading"), font=("Segoe UI", 9, "bold"),
                  bg=CARD, fg=FAINT, anchor="w").pack(
             fill="x", padx=S(18), pady=(S(14), S(4)))
 
         if pending == 0:
-            headline, colour = "Nothing to clear", GOOD
-            body = ("This printer's waste counter is already at its lowest "
-                    "setting. There is nothing for Pad Zero to reset, and "
-                    "nothing you need to do.")
+            headline, colour = t("nothing_to_clear"), GOOD
+            body = t("nothing_to_clear_body")
         elif pending:
-            headline, colour = "Some usage recorded", ACCENT
-            body = ("Resetting would clear %d stored value%s. This printer "
-                    "does not report a percentage, so Pad Zero cannot show "
-                    "you a bar, but the reset works the same way."
-                    % (pending, "" if pending == 1 else "s"))
+            headline, colour = t("some_usage"), ACCENT
+            if pending == 1:
+                body = t("some_usage_body_one", n=pending)
+            else:
+                body = t("some_usage_body_other", n=pending)
         else:
-            headline, colour = "Counter read successfully", DIM
-            body = ("This printer does not report its level as a percentage. "
-                    "Pad Zero can still read and reset it.")
+            headline, colour = t("counter_read_successfully"), DIM
+            body = t("counter_read_successfully_body")
 
         tk.Label(box, text=headline, font=("Segoe UI", 15, "bold"), bg=CARD,
                  fg=colour, anchor="w").pack(fill="x", padx=S(18))
@@ -685,7 +660,7 @@ class App:
                  justify="left", wraplength=S(600)).pack(
             fill="x", padx=S(18), pady=(S(4), S(8)))
         tk.Label(box,
-                 text="The exact numbers are under Technical details below.",
+                 text=t("exact_numbers_hint"),
                  font=F_SMALL, bg=CARD, fg=FAINT, anchor="w").pack(
             fill="x", padx=S(18), pady=(0, S(16)))
 
@@ -710,51 +685,43 @@ class App:
         box = tk.Frame(self.advice, bg=CARD)
         box.pack(fill="x")
         tk.Label(box,
-                 text="Resetting will not empty the pads",
+                 text=t("resetting_will_not_empty"),
                  font=("Segoe UI", 11, "bold"), bg=CARD, fg=WARN,
                  anchor="w").pack(fill="x", padx=16, pady=(12, 2))
         tk.Label(box,
-                 text=("The counter is only an estimate of how much ink has "
-                       "soaked into the pads inside your printer. Resetting it "
-                       "gets you printing again, but the ink is still in there. "
-                       "If the pads are full it can eventually leak out of the "
-                       "bottom.\n\n"
-                       "Put a towel or tray under the printer, and order a "
-                       "replacement pad or a waste tank kit."),
+                 text=t("pad_advice_body"),
                  font=F_SMALL, bg=CARD, fg=DIM, anchor="w", justify="left",
                  wraplength=S(580)).pack(fill="x", padx=16, pady=(0, 10))
-        flat_button(box, "Where to buy a pad",
+        flat_button(box, t("where_to_buy_pad"),
                     lambda: webbrowser.open(PADS_URL),
                     bg=CARD2, fg=FG, font=F_SMALL, padx=14, pady=7).pack(
             anchor="w", padx=16, pady=(0, 14))
 
     def _details(self, text):
-        self.l_details.configure(text=text or "Nothing connected.")
+        self.l_details.configure(text=text or t("nothing_connected"))
 
     def toggle_details(self):
         self.details_open = not self.details_open
         if self.details_open:
             self.details.pack(side="bottom", fill="x", padx=S(24), pady=(S(6), 0),
                               before=self.b_details)
-            self.b_details.configure(text="▾  Technical details")
+            self.b_details.configure(text=t("technical_details_open"))
         else:
             self.details.pack_forget()
-            self.b_details.configure(text="▸  Technical details")
+            self.b_details.configure(text=t("technical_details_closed"))
 
     # ------------------------------------------------------------ actions
     def do_backup(self):
         if not self.printer:
             return
-        self.status("Reading the printer's memory, this takes a moment...")
+        self.status(t("reading_memory"))
         self._run(self.printer.save_dump, "backup")
 
     def after_backup(self, path):
-        self.status("Backup saved", GOOD)
+        self.status(t("backup_saved_status"), GOOD)
         messagebox.showinfo(
-            "Backup saved",
-            "A copy of your printer's settings was saved to:\n\n%s\n\n"
-            "Keep this. If anything ever goes wrong it can be used to put "
-            "things back." % path)
+            t("backup_saved_title"),
+            t("backup_saved_body", path=path))
 
     def do_reset(self):
         pr = self.printer
@@ -763,30 +730,22 @@ class App:
         try:
             plan, _src = pr.reset_plan()
         except Exception as exc:
-            messagebox.showerror("Pad Zero", str(exc))
+            messagebox.showerror(t("app_title"), str(exc))
             return
         if not plan:
             messagebox.showwarning(
-                "Pad Zero", "No reset is known for this model, so nothing "
-                            "will be changed.")
+                t("app_title"), t("no_reset_known"))
             return
 
         ok = messagebox.askyesno(
-            "Reset the waste ink counter?",
-            "This tells your %s that its waste ink pads are empty, so it will "
-            "start printing again.\n\n"
-            "IT DOES NOT EMPTY THE PADS.\n\n"
-            "The ink is still inside the printer. If the pads are full, ink "
-            "can leak out of the bottom onto whatever it is sitting on. Put a "
-            "towel underneath and fit a new pad when you can.\n\n"
-            "A backup is saved automatically before anything is changed.\n\n"
-            "Go ahead?" % pr.model,
+            t("reset_confirm_title"),
+            t("reset_confirm_body", model=pr.model),
             icon="warning", default="no")
         if not ok:
-            self.status("Cancelled")
+            self.status(t("cancelled"))
             return
 
-        self.status("Saving a backup, then resetting...")
+        self.status(t("saving_backup_then_resetting"))
         self._run(lambda: self._reset_work(plan), "reset")
 
     def _reset_work(self, plan):
@@ -800,31 +759,23 @@ class App:
     def after_reset(self, res):
         path, ok, counters, before = res
         self._bars(counters, previous=before)
-        self._log_reading(counters, note="<- after reset" if ok else "")
+        self._log_reading(counters, note=t("after_reset_note") if ok else "")
         if ok:
-            self.status("Done. Turn the printer off and on again.", GOOD)
+            self.status(t("done_power_cycle"), GOOD)
             messagebox.showinfo(
-                "Reset complete",
-                "The counter has been reset.\n\n"
-                "NEXT: turn the printer off, wait ten seconds, and turn it "
-                "back on. It should print again.\n\n"
-                "Then order a replacement pad. The ink is still inside the "
-                "printer and this will happen again.\n\n"
-                "Backup saved to:\n%s" % path)
+                t("reset_complete_title"),
+                t("reset_complete_body", path=path))
             # deliberately not re-scanning: that would wipe the before/after
             # comparison off the screen, which is the proof it worked
         else:
-            self.status("Some changes were refused", BAD)
+            self.status(t("some_changes_refused"), BAD)
             messagebox.showerror(
-                "Reset did not finish",
-                "The printer refused some of the changes.\n\n"
-                "Your backup is safe at:\n%s\n\n"
-                "This usually means the printer's firmware blocks resets. "
-                "Nothing has been damaged." % path)
+                t("reset_did_not_finish_title"),
+                t("reset_did_not_finish_body", path=path))
 
     def show_explain(self):
         win = tk.Toplevel(self.root, bg=BG)
-        win.title("What Pad Zero does")
+        win.title(t("what_pad_zero_does"))
         win.geometry("640x560")
         win.transient(self.root)
         frame = tk.Frame(win, bg=CARD)
@@ -833,9 +784,9 @@ class App:
                       relief="flat", padx=20, pady=20, bd=0,
                       highlightthickness=0)
         txt.pack(fill="both", expand=True)
-        txt.insert("1.0", core.EXPLAIN.strip())
+        txt.insert("1.0", t("explain_body"))
         txt.configure(state="disabled")
-        flat_button(win, "Close", win.destroy).pack(pady=(0, 16))
+        flat_button(win, t("close"), win.destroy).pack(pady=(0, 16))
 
 
 def main():
@@ -852,11 +803,10 @@ def main():
             import ctypes
             ctypes.windll.user32.MessageBoxW(
                 0,
-                "Pad Zero could not open its window.\n\n%s\n\n"
-                "This is usually a missing Tcl/Tk installation." % exc,
-                "Pad Zero", 0x10)
+                t("could_not_open_window", error=exc),
+                t("app_title"), 0x10)
         except Exception:
-            print("Could not start: %s" % exc)
+            print(t("could_not_start", error=exc))
         return 1
 
     try:
@@ -867,9 +817,8 @@ def main():
         detail = traceback.format_exc()
         try:
             messagebox.showerror(
-                "Pad Zero stopped unexpectedly",
-                "Something went wrong.\n\nPlease copy this and open an issue "
-                "at:\n%s\n\n%s" % (ISSUES_URL, detail[-1500:]))
+                t("stopped_unexpectedly_title"),
+                t("stopped_unexpectedly_body", url=ISSUES_URL, detail=detail[-1500:]))
         except Exception:
             print(detail)
         return 1


### PR DESCRIPTION
## Summary

- Extract the window copy into `i18n/en.py` (current English, unchanged) and `i18n/es.py` (Latin American Spanish).
- Pick Spanish when Windows (or `LANG` / `LC_*`) is a Spanish locale; otherwise keep English.
- `PADZERO_LANG=en` or `es` forces one language for testing.

Closes #1

## Changes

- New `i18n` package with `t()` and a key-parity check between catalogs.
- `padzero_gui.py` uses `t(...)` for buttons, statuses, the pad warning, confirmations, and “What is this?”.
- Left in English: `model` / `serial` / `key group` / `coverage` / `reset map` in Technical details, `LINE`/`EXT`, model names, and the CLI.

## Test Plan

- [x] Catalogs have the same 84 keys and matching `{placeholders}`
- [x] `import padzero_gui` succeeds
- [x] Window launches with `PADZERO_LANG=es` without crashing
- [x] `PADZERO_LANG=en`: every `t()` key matches `i18n/en.py` (the original English wording)
- [x] Spanish pad-warning and reset-confirmation strings resolve (`PADZERO_LANG=es`); on-printer click-through of those dialogs still worth a glance on review

## Notes for Reviewers

Tone is the same as the English: plain, no hype, especially on “resetting does not empty the pads.” CLI can follow in a later PR, as discussed in #1.